### PR TITLE
Support for object reference animations

### DIFF
--- a/Editor/FlarePlugin.cs
+++ b/Editor/FlarePlugin.cs
@@ -17,12 +17,13 @@ namespace Flare.Editor
             
             // Clone animators (using the Modular Avatar implementation... ty bd_ <3)
             InPhase(BuildPhase.Generating).Run("Clone Animators (MA Impl)", AnimationUtilities.CloneAllControllers);
-            InPhase(BuildPhase.Generating).Run<ContainerizationPass>();
+            //InPhase(BuildPhase.Generating).Run<ContainerizationPass>();
             InPhase(BuildPhase.Generating).Run<ParameterGenerationPass>();
             
             InPhase(BuildPhase.Transforming)
                 .AfterPlugin("nadena.dev.modular-avatar")
-                .Run<MenuGenerationPass>()
+                .Run<ContainerizationPass>()
+                .Then.Run<MenuGenerationPass>()
                 .Then.Run<ControlPass>()
                 .Then.Run<ParametrizationPass>()
                 .Then.Run<MenuizationPass>()

--- a/Editor/Models/AnimatableBinaryProperty.cs
+++ b/Editor/Models/AnimatableBinaryProperty.cs
@@ -10,11 +10,11 @@ namespace Flare.Editor.Models
         
         public string Name { get; }
         
-        public float DefaultValue { get; }
+        public object DefaultValue { get; }
         
-        public float InverseValue { get; }
+        public object InverseValue { get; }
 
-        public AnimatableBinaryProperty(Type type, string path, string name, float defaultValue, float inverseValue)
+        public AnimatableBinaryProperty(Type type, string path, string name, object defaultValue, object inverseValue)
         {
             Type = type;
             Path = path;
@@ -23,7 +23,7 @@ namespace Flare.Editor.Models
             InverseValue = inverseValue;
         }
 
-        public void Deconstruct(out string path, out Type type, out string name, out float defaultValue, out float inverseValue)
+        public void Deconstruct(out string path, out Type type, out string name, out object defaultValue, out object inverseValue)
         {
             path = Path;
             type = Type;

--- a/Editor/Passes/ContainerizationPass.cs
+++ b/Editor/Passes/ContainerizationPass.cs
@@ -173,6 +173,8 @@ namespace Flare.Editor.Passes
                                     
                                     Analog = property.Analog,
                                     Vector = property.Vector,
+                                    Object = property.Object,
+                                    ObjectType = property.ObjectType,
                                     OverrideDefaultValue = property.OverrideDefaultValue,
                                     OverrideDefaultAnalog = property.OverrideDefaultAnalog,
                                     OverrideDefaultVector = property.OverrideDefaultVector,

--- a/Editor/Passes/ContainerizationPass.cs
+++ b/Editor/Passes/ContainerizationPass.cs
@@ -213,8 +213,17 @@ namespace Flare.Editor.Passes
             }
 
             var propertyContext = flare.GetPropertyContext(prop);
-            var propertyPath = propertyContext.AsNullable()?.transform.GetAnimatablePath(buildContext.AvatarRootTransform) ?? prop.Path;
-            
+            var propertyPath = propertyContext.AsNullable()?.transform.GetAnimatablePath(buildContext.AvatarRootTransform);
+
+            if (propertyPath == null)
+            {
+                propertyPath = prop.Path;
+                Debug.Log("no component found for " + prop.Path);
+            }
+
+            if (propertyPath != prop.Path)
+                Debug.Log("Moved '" + prop.Path + "' to '" + propertyPath + "'.");
+
             // ReSharper disable once ConvertIfStatementToSwitchStatement
             if (prop.ValueType is PropertyValueType.Float or PropertyValueType.Boolean or PropertyValueType.Integer)
             {

--- a/Editor/Passes/ContainerizationPass.cs
+++ b/Editor/Passes/ContainerizationPass.cs
@@ -213,16 +213,7 @@ namespace Flare.Editor.Passes
             }
 
             var propertyContext = flare.GetPropertyContext(prop);
-            var propertyPath = propertyContext.AsNullable()?.transform.GetAnimatablePath(buildContext.AvatarRootTransform);
-
-            if (propertyPath == null)
-            {
-                propertyPath = prop.Path;
-                Debug.Log("no component found for " + prop.Path);
-            }
-
-            if (propertyPath != prop.Path)
-                Debug.Log("Moved '" + prop.Path + "' to '" + propertyPath + "'.");
+            var propertyPath = propertyContext.AsNullable()?.transform.GetAnimatablePath(buildContext.AvatarRootTransform) ?? prop.Path;
 
             // ReSharper disable once ConvertIfStatementToSwitchStatement
             if (prop.ValueType is PropertyValueType.Float or PropertyValueType.Boolean or PropertyValueType.Integer)

--- a/Editor/Passes/ContainerizationPass.cs
+++ b/Editor/Passes/ContainerizationPass.cs
@@ -404,7 +404,7 @@ namespace Flare.Editor.Passes
                 if (prop.OverrideDefaultValue)
                 {
                     // Automatically assign these values on the base on upload for avatar preview.
-                    TryAssignDefaultToAvatar(flare, targetDefaultValue, type, prop, name, index);
+                    TryAssignDefaultToAvatar(flare, defaultValue, type, prop, name, index);
                 }
 
                 AnimatableBinaryProperty property = new(type, path, name, targetDefaultValue, targetInverseValue);

--- a/Editor/Passes/ContainerizationPass.cs
+++ b/Editor/Passes/ContainerizationPass.cs
@@ -168,7 +168,7 @@ namespace Flare.Editor.Passes
                                     State = property.State,
                                     ColorType = property.ColorType,
                                     ValueType = property.ValueType,
-                                    ContextType = property.ContextType,
+                                    ContextType = c.GetType().AssemblyQualifiedName,
                                     Path = c.transform.GetAnimatablePath(avatarRoot),
                                     
                                     Analog = property.Analog,

--- a/Editor/Services/BindingService.cs
+++ b/Editor/Services/BindingService.cs
@@ -49,7 +49,7 @@ namespace Flare.Editor.Services
             return (T)GetPropertyValue(property);
         }
 
-        public float GetPropertyValue(FlarePseudoProperty property)
+        public object GetPropertyValue(FlarePseudoProperty property)
         {
             _ = AnimationUtility.GetFloatValue(_root, property.Binding, out var pseudoDefault);
             return pseudoDefault;
@@ -82,6 +82,12 @@ namespace Flare.Editor.Services
                 }
                 return value;
             }
+
+            UnityEngine.Object GetObjectValue(FlareProperty prop)
+            {
+                _ = AnimationUtility.GetObjectReferenceValue(_root, prop.GetPseudoProperty(0).Binding, out var objectValue);
+                return objectValue;
+            }
             
             // The Allocator 9000
             object value = property.Type switch
@@ -92,6 +98,7 @@ namespace Flare.Editor.Services
                 PropertyValueType.Vector2 => GetVectorValue(property),
                 PropertyValueType.Vector3 => GetVectorValue(property),
                 PropertyValueType.Vector4 => GetVectorValue(property),
+                PropertyValueType.Object => GetObjectValue(property),
                 _ => throw new ArgumentOutOfRangeException()
             };
             
@@ -134,10 +141,10 @@ namespace Flare.Editor.Services
                         return null;
                     
                     var type = AnimationUtility.GetEditorCurveValueType(_root, binding);
-                    
+
                     // For the time being we'll only be working with the primitive float, int, and bool properties.
                     // In the future we may be able to support others like Materials and such.
-                    if (type != typeof(float) && type != typeof(int) && type != typeof(bool))
+                    if (type != typeof(float) && type != typeof(int) && type != typeof(bool) && type != typeof(Material))
                         return null;
                     
                     if (preSearch == null)
@@ -265,6 +272,8 @@ namespace Flare.Editor.Services
                     propertyType = PropertyValueType.Float;
                 else if (type == typeof(int))
                     propertyType = PropertyValueType.Integer;
+                else if (typeof(UnityEngine.Object).IsAssignableFrom(type))
+                    propertyType = PropertyValueType.Object;
                 else
                     propertyType = PropertyValueType.Boolean;
 

--- a/Editor/Windows/PropertySelectorWindow.cs
+++ b/Editor/Windows/PropertySelectorWindow.cs
@@ -9,6 +9,7 @@ using Flare.Models;
 using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine;
+using UnityEngine.Pool;
 using UnityEngine.UIElements;
 using VRC.SDKBase;
 using PropertyInfo = Flare.Models.PropertyInfo;

--- a/Editor/Windows/PropertySelectorWindow.cs
+++ b/Editor/Windows/PropertySelectorWindow.cs
@@ -96,6 +96,7 @@ namespace Flare.Editor.Windows
             buttonGroup.CreateButton("Blendshapes", () => searchField.value = "t:Blendshape ").WithGrow(1f);
             buttonGroup.CreateButton("Materials", () => searchField.value = "t:Material ").WithGrow(1f);
             buttonGroup.CreateButton("Everything", () => searchField.value = string.Empty).WithGrow(1f);
+            searchField.Focus();
 
             var bindingSearch = binder.GetPropertyBindings().Where(b => b.GameObject != avatarGameObject);
             if (propertyGroup.SelectionType is PropertySelectionType.Avatar)

--- a/Editor/Windows/PropertySelectorWindow.cs
+++ b/Editor/Windows/PropertySelectorWindow.cs
@@ -185,6 +185,14 @@ namespace Flare.Editor.Windows
                             property.Property(nameof(PropertyInfo.Vector)).SetValue(defaultValue);
                             break;
                         }
+                        case PropertyValueType.Object:
+                        {
+                            var defaultValue = (UnityEngine.Object)binder.GetPropertyValue(binding);
+                            property.Property(nameof(PropertyInfo.Object)).SetValue(defaultValue);
+                            var objectType = binding.GetPseudoProperty(0).Type;
+                            property.Property(nameof(PropertyInfo.ObjectType)).SetValue(objectType.AssemblyQualifiedName);
+                            break;
+                        }
                     }
                     
                     Close();

--- a/Runtime/Models/PropertyInfo.cs
+++ b/Runtime/Models/PropertyInfo.cs
@@ -28,6 +28,12 @@ namespace Flare.Models
         public Vector4 Vector { get; internal set; }
 
         [field: SerializeField]
+        public UnityEngine.Object Object { get; internal set; }
+
+        [field: SerializeField]
+        public string ObjectType { get; internal set; }
+
+        [field: SerializeField]
         public ControlState State { get; internal set; }
 
         [field: SerializeField]
@@ -35,6 +41,9 @@ namespace Flare.Models
 
         [field: SerializeField]
         public float OverrideDefaultAnalog { get; internal set; }
+
+        [field: SerializeField]
+        public UnityEngine.Object OverrideDefaultObject { get; internal set; }
 
         [field: SerializeField]
         public Vector4 OverrideDefaultVector { get; internal set; }

--- a/Runtime/Models/PropertyValueType.cs
+++ b/Runtime/Models/PropertyValueType.cs
@@ -7,6 +7,7 @@
         Float,
         Vector2,
         Vector3,
-        Vector4
+        Vector4,
+        Object
     }
 }


### PR DESCRIPTION
Only material animations are fully supported at the moment due to other object types not having support in `ContainerizationPass.TryAssignDefaultToAvatar`. The property selector only shows material properties for now because of this.

Also includes four small fixes:
- Changed the default value that gets assigned to the avatar to reflect the ui (specifically the 'Default Value (While Active/Inactive)` text.) This may be a difference in philosophy, but IMO it should be this way because it allows you to have a default avatar state that is independent of the value of your enable/disable states.
- Property selector window now focuses the search box when it opens, so you dont have to click on the search bar.
- Moved the ContainerizationPass to execute just before the rest of our passes, but still after Modular Avatar. This ensures that the animation paths haven't changed between it and the rest of our passes. (This theoretically shouldn't break anything, but if you think it does lmk.)
- Merged Renderer types in the selector. This is more user friendly and allows Avatar animations to be applied to any renderer type. Added a toggle for this feature in the future, once the UI is able to properly show this difference to the user.

I thought about adding a new category in the property selector for non-blendshape/material properties, so that they are easier to find. I couldn't think of a good short name for a category that fits those parameters though, so if you have any suggestions it'd be appreciated. Another alternative would to be to sort those parameters to always be at the top of the 'everything' tab, but I decided against messing with the magical optimized aggregation algorithm.

[Related Sucrose PR](https://github.com/Auros/Sucrose/pull/1)